### PR TITLE
Add_horizontal_line and read X,Y when left click

### DIFF
--- a/t_rax/controller/BaseController.py
+++ b/t_rax/controller/BaseController.py
@@ -141,7 +141,7 @@ class BaseController(QtCore.QObject):
         self.model.roi = self.widget.roi_widget.get_rois()[0]
 
     def graph_mouse_moved(self, x, y):
-        self.widget.graph_mouse_pos_lbl.setText("X: {:8.2f}  Y: {:8.2f}".format(x, y))
+        self.widget.graph_mouse_pos_lbl.setText("X: {:8.2f} Y: {:8.2f}".format(x, y))
 
     def img_mouse_moved(self, x, y):
         x = int(np.floor(x))

--- a/t_rax/controller/RamanController.py
+++ b/t_rax/controller/RamanController.py
@@ -91,7 +91,8 @@ class RamanController(QtCore.QObject):
     def sample_pos_txt_changed(self):
         new_value = float(str(self.widget.sample_position_txt.text()))
         self.model.sample_position = new_value
-        self.widget.set_raman_line_pos(new_value)
+        self.widget.set_raman_vertical_line_pos(new_value)
+        self.widget.set_raman_horizontal_line_pos(new_value)
 
     def display_mode_changed(self):
         if self.widget.nanometer_cb.isChecked():
@@ -107,8 +108,19 @@ class RamanController(QtCore.QObject):
 
     def mouse_left_clicked(self, x, y):
         self.model.sample_position = x
+        self.model.sample_position = y
         self.widget.sample_position_txt.setText("{:.2f}".format(x))
-        self.widget.set_raman_line_pos(x)
+        self.widget.set_raman_vertical_line_pos(x)
+        self.widget.set_raman_horizontal_line_pos(y)
+        if self.widget.nanometer_cb.isChecked():
+            x1 = self.model.convert_wavelength_to_reverse_cm(x, self.model.laser_line)
+            self.widget.graph_mouse_click_pos_lbl.setText(
+                "X: {:8.2f} nm , {:8.2f} cm<sup>-1</sup>     Y: {:8.2f}".format(x, x1, y))
+        elif self.widget.reverse_cm_cb.isChecked():
+            x1 = self.model.convert_reverse_cm_to_wavelength(x, self.model.laser_line)
+            self.widget.graph_mouse_click_pos_lbl.setText(
+                "X: {:8.2f} nm , {:8.2f} cm<sup>-1</sup>     Y: {:8.2f}".format(x1, x, y))
+
         if self.model.mode == RamanModel.REVERSE_CM_MODE:
             x = self.model.convert_reverse_cm_to_wavelength(x, self.model.laser_line)
         ind = self.model.get_roi_ind_from_wavelength(x)
@@ -117,7 +129,8 @@ class RamanController(QtCore.QObject):
     def update_widget_parameter(self):
         self.widget.laser_line_txt.setText("{:.2f}".format(self.model.laser_line))
         self.widget.sample_position_txt.setText("{:.2f}".format(self.model.sample_position))
-        self.widget.set_raman_line_pos(self.model.sample_position)
+        self.widget.set_raman_vertical_line_pos(self.model.sample_position)
+        self.widget.set_raman_horizontal_line_pos(self.model.sample_position)
         if self.model.mode == RamanModel.WAVELENGTH_MODE:
             self.widget.nanometer_cb.setChecked(True)
 

--- a/t_rax/controller/RamanController.py
+++ b/t_rax/controller/RamanController.py
@@ -24,6 +24,25 @@ from ..model.RamanModel import RamanModel
 from ..controller.BaseController import BaseController
 
 
+class RamanBaseController(BaseController):
+    def __init__(self, model, widget):
+        """
+        :type widget: BaseWidget
+        :type model: SingleSpectrumModel
+        """
+        super(RamanBaseController, self).__init__(model, widget)
+
+    def graph_mouse_moved(self, x, y):
+        if self.widget.nanometer_cb.isChecked():
+            x1 = self.model.convert_wavelength_to_reverse_cm(x, self.model.laser_line)
+            self.widget.graph_mouse_pos_lbl.setText(
+                "X: {:8.2f} nm , {:8.2f} cm<sup>-1</sup>   Y: {:8.2f}".format(x, x1, y))
+        elif self.widget.reverse_cm_cb.isChecked():
+            x1 = self.model.convert_reverse_cm_to_wavelength(x, self.model.laser_line)
+            self.widget.graph_mouse_pos_lbl.setText(
+                "X: {:8.2f} nm , {:8.2f} cm<sup>-1</sup>   Y: {:8.2f}".format(x1, x, y))
+
+
 class RamanController(QtCore.QObject):
     def __init__(self, model, widget):
         """
@@ -35,7 +54,7 @@ class RamanController(QtCore.QObject):
         """
         super(RamanController, self).__init__()
 
-        self.base_controller = BaseController(model, widget)
+        self.base_controller = RamanBaseController(model, widget)
 
         self.model = model
         self.widget = widget

--- a/t_rax/model/BaseModel.py
+++ b/t_rax/model/BaseModel.py
@@ -136,6 +136,8 @@ class SingleSpectrumModel(QtCore.QObject, object):
                                                                     self.spe_file.detector)
 
     def get_roi_ind_from_wavelength(self, wl):
+        if self._data_img_x_calibration is None:
+            return 1
         ind = (np.abs(self._data_img_x_calibration - wl)).argmin()
         return ind
 

--- a/t_rax/widget/BaseWidget.py
+++ b/t_rax/widget/BaseWidget.py
@@ -90,6 +90,7 @@ class BaseWidget(QtWidgets.QWidget):
 
         self.graph_info_lbl = self.graph_status_bar.right_lbl
         self.graph_mouse_pos_lbl = self.graph_status_bar.left_lbl
+        self.graph_mouse_click_pos_lbl = self.graph_status_bar.bottom_lbl
 
     def add_control_widget(self, widget):
         self.control_widget._layout.insertWidget(self.control_widget._layout.count() - 1, widget)

--- a/t_rax/widget/RamanWidget.py
+++ b/t_rax/widget/RamanWidget.py
@@ -63,18 +63,27 @@ class RamanWidget(BaseWidget, object):
         self.overlay_offset_sb = self.overlay_gb.offset_sb
 
     def modify_graph_widget(self):
-        self._raman_line = pg.InfiniteLine(pen=pg.mkPen((0, 197, 3), width=2))
-        self.graph_widget.add_item(self._raman_line)
+        self._raman_vertical_line = pg.InfiniteLine(angle=90, pen=pg.mkPen((0, 197, 3), width=2))
+        self.graph_widget.add_item(self._raman_vertical_line)
+        self._raman_horizontal_line = pg.InfiniteLine(angle=0, pen=pg.mkPen((0, 197, 3), width=2))
+        self.graph_widget.add_item(self._raman_horizontal_line)
 
     def modify_roi_widget(self):
         self._raman_roi_line = pg.InfiniteLine(pen=pg.mkPen((0, 197, 3), width=2))
         self.roi_widget.add_item(self._raman_roi_line)
 
-    def set_raman_line_pos(self, value):
-        self._raman_line.setValue(value)
+    def set_raman_vertical_line_pos(self, value):
+        self._raman_vertical_line.setValue(value)
 
-    def get_raman_line_pos(self):
-        return self._raman_line.value()
+    def get_raman_vertical_line_pos(self):
+        return self._raman_vertical_line.value()
+
+    def set_raman_horizontal_line_pos(self, value):
+        self._raman_horizontal_line.setValue(value)
+
+    def get_raman_horizontal_line_pos(self):
+        return self._raman_horizontal_line.value()
+
 
     def set_raman_roi_line_pos(self, value):
         self._raman_roi_line.setValue(value)

--- a/t_rax/widget/Widgets.py
+++ b/t_rax/widget/Widgets.py
@@ -144,19 +144,25 @@ class StatusBar(QtWidgets.QWidget):
     def create_widgets(self):
         self.left_lbl = QtWidgets.QLabel()
         self.right_lbl = QtWidgets.QLabel()
+        self.bottom_lbl = QtWidgets.QLabel()
 
     def create_layout(self):
-        self._layout = QtWidgets.QHBoxLayout()
-        self._layout.addWidget(self.left_lbl)
-        self._layout.addSpacerItem(QtWidgets.QSpacerItem(QtWidgets.QSpacerItem(10, 10,
+        self._layout = QtWidgets.QVBoxLayout()
+        self._top_status_layout = QtWidgets.QHBoxLayout()
+        self._top_status_layout.addWidget(self.left_lbl)
+        self._top_status_layout.addSpacerItem(QtWidgets.QSpacerItem(QtWidgets.QSpacerItem(10, 10,
                                                                        QtWidgets.QSizePolicy.Expanding,
                                                                        QtWidgets.QSizePolicy.Fixed)))
-        self._layout.addWidget(self.right_lbl)
+        self._top_status_layout.addWidget(self.right_lbl)
+
+        self._layout.addLayout(self._top_status_layout)
+        self._layout.addWidget(self.bottom_lbl)
 
         self.setLayout(self._layout)
 
     def style_widgets(self):
         self._layout.setContentsMargins(8, 0, 8, 0)
+        self.bottom_lbl.setStyleSheet("color: #00C503")
 
 
 def open_file_dialog(parent_widget, caption, directory, filter=None):


### PR DESCRIPTION
Wanted to add a horizontal line in the Raman plot when left mouse clicked. Added raman_horizontal_line.

Wanted to add a second label in the bottom of the Raman plot that reads the X,Y positions of the last left mouse click on the spectrum. Created a layout and added bottom_label widget that prints text in green color.